### PR TITLE
Updating XML saving code to be consistent with mdoc

### DIFF
--- a/tripled/Program.cs
+++ b/tripled/Program.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -138,12 +139,24 @@ namespace tripled
             }
             else if (fileDirty)
             {
-                var xws = new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true };
-                using (var xw = XmlWriter.Create(file, xws))
+                // these settings align with mdoc's XML settings
+                var settings = new XmlWriterSettings()
+                {
+                    NewLineChars = "\n",
+                    OmitXmlDeclaration = true,
+                    Indent = true,
+                    IndentChars = "  "
+                };
+
+                using (var stream = new StreamWriter(file, false, new UTF8Encoding(false)))
+                using (var xw = XmlWriter.Create(stream, settings))
                 {
                     try
                     {
                         xml.Save(xw);
+                        xw.Dispose();
+                        stream.WriteLine(); // trailing line break
+                        stream.Dispose();
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Tripled is currently outputting a unicode byte order mark when it saves a file, and additionally removes the trailing line break that mdoc always adds. This causes noisy whitespace changes any time tripled has to intercede on a given file.

This change brings tripled in line with the same settings that mdoc uses [here](https://github.com/mono/api-doc-tools/blob/master/mdoc/Mono.Documentation/MDocUpdater.cs#L554) and [here](https://github.com/mono/api-doc-tools/blob/master/mdoc/Mono.Documentation/MDocUpdater.cs#L1400) ... note, the code isn't exactly the same because mdoc uses the `XmlDocument` API, while tripled uses `XDocument`; as a result the code to configure the stream and writer are slightly different.